### PR TITLE
[#22, #23] 공격 및 스킬 버그 수정

### DIFF
--- a/Source/ProejctUN/GA/TA/UNTA_SphereMultiTrace.cpp
+++ b/Source/ProejctUN/GA/TA/UNTA_SphereMultiTrace.cpp
@@ -32,17 +32,12 @@ FGameplayAbilityTargetDataHandle AUNTA_SphereMultiTrace::MakeTargetData() const
 
 	FVector Origin = Character->GetActorLocation();
 	FCollisionQueryParams Params(SCENE_QUERY_STAT(AUNTA_SphereMultiTrace), false, Character);
-	GetWorld()->OverlapMultiByChannel(Overlaps, Origin, FQuat::Identity, CCHANNEL_UNACTION, FCollisionShape::MakeSphere(SkillRadius));
+	GetWorld()->OverlapMultiByChannel(Overlaps, Origin, FQuat::Identity, CCHANNEL_UNACTION, FCollisionShape::MakeSphere(SkillRadius), Params);
 
 	TArray<TWeakObjectPtr<AActor>> HitActors;
 	for (const FOverlapResult& Overlap : Overlaps)
 	{
 		AActor* HitActor = Overlap.OverlapObjectHandle.FetchActor<AActor>();
-
-		if (SourceActor == HitActor)
-		{
-			continue;
-		}
 
 		if (HitActor && !HitActors.Contains(HitActor))
 		{

--- a/Source/ProejctUN/GA/UNGA_AttackHitCheck.cpp
+++ b/Source/ProejctUN/GA/UNGA_AttackHitCheck.cpp
@@ -33,9 +33,14 @@ void UUNGA_AttackHitCheck::OnTraceResultCallback(const FGameplayAbilityTargetDat
 
 		UAbilitySystemComponent* SourceASC = GetAbilitySystemComponentFromActorInfo_Checked();
 		UAbilitySystemComponent* TargetASC = UAbilitySystemBlueprintLibrary::GetAbilitySystemComponent(HitResult.GetActor());
+
 		if (!SourceASC || !TargetASC)
 		{
 			UE_LOG(LogTemp, Log, TEXT("Not Have ASC!"));
+
+			bool bReplicatedEndAbility = true;
+			bool bWasCancelled = true;
+			EndAbility(CurrentSpecHandle, CurrentActorInfo, CurrentActivationInfo, bReplicatedEndAbility, bWasCancelled);
 			return;
 		}
 


### PR DESCRIPTION
- ASC가 없는 액터 공격 시 공격 기능을 상실하는 버그 수정
- 버그 발생 이유는 ASC가 없는 액터 타격 시 EndAbility를 호출하지 않고 바로 return시켰기 때문..

![image](https://github.com/futurelabunseen/A-JiminLee/assets/86705754/099b6a38-2ae7-41eb-913c-ba45f7d39d3e)
![image](https://github.com/futurelabunseen/A-JiminLee/assets/86705754/a0c612cb-b860-43c1-a010-c62067504de9)


- 스킬 사용 시 자기 자신도 데미지를 입는 버그 수정
- 버그 발생 이유는 FCollisionQueryParams을 잘 만들어놔놓고 인자에 넣질 않았음..

![image](https://github.com/futurelabunseen/A-JiminLee/assets/86705754/6fe630c0-7e3a-4acb-9a92-6985ce10ba14)
